### PR TITLE
Changes sh to bash and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-# ConfigServer Security & Firewall (CSF) - csfpre.sh / csfpost.sh
+# ConfigServer Security & Firewall (CSF) – csfpre.sh / csfpost.sh
 
-## Install
-Installation is quite straightforward:
+Installs a pre- and a post script for the CSF firewall that will be executed on every (re-)start.
+
+## Installation
+
+Installation is quite straightforward. Remember to execute most of these commands with admin privileges (`sudo su`):
 
 ```
-# cd /usr/local/src
-# git clone https://github.com/juliengk/csf-pre_post_sh.git
-# cd csf-pre_post_sh
-# sh install.sh
+# Clone repo and start installation
+$ cd /usr/local/src
+$ git clone https://github.com/juliengk/csf-pre_post_sh.git
+$ cd csf-pre_post_sh
+$ ./install.sh
+
+# Restart CSF
+$ csf -ra
 ```
 
 ## User Feedback
 ### Issues
 
 If you have any problems with or questions about this image, please contact us through a [GitHub](https://github.com/juliengk/csf-pre_post_sh/issues) issue.
+

--- a/csfpost.sh
+++ b/csfpost.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CSFPOSTD_PATH="/usr/local/include/csf/post.d"
 

--- a/csfpre.sh
+++ b/csfpre.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CSFPRED_PATH="/usr/local/include/csf/pre.d"
 

--- a/install.sh
+++ b/install.sh
@@ -45,18 +45,6 @@ function copy_script {
 	chmod 700 ${csf_dst_path}
 }
 
-# Verify /bin/bash is linked to /bin/sh
-shell="bash"
-sh_shell=`ls -l /bin/sh | awk '{ print $NF }'`
-
-if [ ${sh_shell} != ${shell} -a ${sh_shell} != "/bin/${shell}" ]; then
-	echo "** Critical! **"
-	echo "/bin/sh is not linked to /bin/${shell}. Yours is ${sh_shell}."
-	echo "Only /bin/${shell} is supported"
-
-	exit 1
-fi
-
 # Create directories needed for custom csf{pre,post}
 if [ ! -d ${CSFPRED_PATH} ]; then
 	mkdir -p ${CSFPRED_PATH}


### PR DESCRIPTION
Fixes #1 and fixes #2 .

Like mentioned in the issues, it isn't a good idea to change `/bin/sh` to `/bin/bash` in the Ubuntu system.
Simply switching to `bash` should solve these problems.

Tested on Ubuntu 20.04 LTS.